### PR TITLE
Ensure pluck, count, first, etc work

### DIFF
--- a/lib/active_record/associations/has_many_split_through_association.rb
+++ b/lib/active_record/associations/has_many_split_through_association.rb
@@ -12,18 +12,31 @@ module ActiveRecord
         join_ids = [association.owner.id]
         records = nil
 
-        chain.reverse.each do |refl|
+        reverse_chain = chain.reverse
+        last_reflection = reverse_chain.last
+        reverse_chain.each do |refl|
           records = refl.klass.unscoped.where(refl.join_keys.key => join_ids)
-          join_ids = records.map(&:id)
+          # Preventing the reflection from being loaded on the
+          # last reflection in the chain, that way anything the user
+          # wants to apply to the reflection will still work.
+          if refl != last_reflection
+            records = records.select(:id)
+            join_ids = records.map(&:id)
+          end
         end
 
         records
       end
     end
+
     # = Active Record Has Many Through Association
     class HasManySplitThroughAssociation < HasManyThroughAssociation #:nodoc:
-      def find_target
+      def scope
         SplitAssociationScope.create.scope(self)
+      end
+
+      def find_target
+        scope
       end
     end
   end


### PR DESCRIPTION
Implements ability to reuse scope for pluck, first, count, etc and
updates the tests.

This implementation requires no changes to Rails 6.0 or Rails 5.2.

In order to ensure pluck and friends work correctly we need to not map
all the join ids at the end of the scope chain loop and instead select
the ids from the last reflection in the chain.

Co-authored-by: Aaron Patterson <aaron.patterson@gmail.com>

cc/ @myobie @tenderlove