### PR TITLE
Select the correct foreign key when joining

### DIFF
--- a/lib/active_record/associations/has_many_split_through_association.rb
+++ b/lib/active_record/associations/has_many_split_through_association.rb
@@ -4,24 +4,31 @@ module ActiveRecord
   module Associations
     class SplitAssociationScope < AssociationScope
       def scope(association)
+        # source of the through reflection
         reflection = association.reflection
+        #remove all previously set scope of passed in association
         scope = association.klass.unscoped
 
         chain = get_chain(reflection, association, scope.alias_tracker)
 
         reverse_chain = chain.reverse
-        first_refl = reverse_chain.shift
+        first_reflection = reverse_chain.shift
         first_join_ids = [association.owner.id]
+        initial_values = [first_reflection, first_join_ids]
 
-        last_refl, last_join_ids = reverse_chain.inject([first_refl, first_join_ids]) do |(prev_refl, prev_join_ids), next_refl|
-          records = prev_refl.klass.unscoped.where(prev_refl.join_keys.key => prev_join_ids)
+        last_reflection, join_ids = reverse_chain.inject(initial_values) do |(reflection, join_ids), next_reflection|
+          key = reflection.join_keys.key
+          records = reflection.klass.where(key => join_ids)
+
           # Preventing the reflection from being loaded on the
           # last reflection in the chain, that way anything the user
           # wants to apply to the reflection will still work.
-          [next_refl, records.pluck(next_refl.join_keys.foreign_key)]
+          foreign_key = next_reflection.join_keys.foreign_key
+          [next_reflection, records.pluck(foreign_key)]
         end
 
-        last_refl.klass.unscoped.where(last_refl.join_keys.key => last_join_ids)
+        key = last_reflection.join_keys.key
+        last_reflection.klass.where(key => join_ids)
       end
     end
 

--- a/lib/active_record/associations/has_many_split_through_association.rb
+++ b/lib/active_record/associations/has_many_split_through_association.rb
@@ -18,7 +18,8 @@ module ActiveRecord
 
         last_reflection, last_join_ids = reverse_chain.inject(initial_values) do |(reflection, join_ids), next_reflection|
           key = reflection.join_keys.key
-          records = reflection.klass.where(key => join_ids)
+          where_sql = ActiveRecord::Base.sanitize_sql(["#{key} IN (?)", join_ids])
+          records = reflection.klass.where(where_sql)
 
           # Preventing the reflection from being loaded on the
           # last reflection in the chain, that way anything the user

--- a/lib/active_record/associations/has_many_split_through_association.rb
+++ b/lib/active_record/associations/has_many_split_through_association.rb
@@ -16,7 +16,7 @@ module ActiveRecord
         first_join_ids = [association.owner.id]
         initial_values = [first_reflection, first_join_ids]
 
-        last_reflection, join_ids = reverse_chain.inject(initial_values) do |(reflection, join_ids), next_reflection|
+        last_reflection, last_join_ids = reverse_chain.inject(initial_values) do |(reflection, join_ids), next_reflection|
           key = reflection.join_keys.key
           records = reflection.klass.where(key => join_ids)
 
@@ -28,7 +28,7 @@ module ActiveRecord
         end
 
         key = last_reflection.join_keys.key
-        last_reflection.klass.where(key => join_ids)
+        last_reflection.klass.where(key => last_join_ids)
       end
     end
 

--- a/lib/active_record/associations/has_many_split_through_association.rb
+++ b/lib/active_record/associations/has_many_split_through_association.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       def scope(association)
         # source of the through reflection
         source_reflection = association.reflection
-        #remove all previously set scope of passed in association
+        # remove all previously set scopes of passed in association
         scope = association.klass.unscoped
 
         chain = get_chain(source_reflection, association, scope.alias_tracker)
@@ -14,22 +14,29 @@ module ActiveRecord
         reverse_chain = chain.reverse
         first_reflection = reverse_chain.shift
         first_join_ids = [association.owner.id]
+
         initial_values = [first_reflection, first_join_ids]
 
         last_reflection, last_join_ids = reverse_chain.inject(initial_values) do |(reflection, join_ids), next_reflection|
           key = reflection.join_keys.key
-          where_sql = ActiveRecord::Base.sanitize_sql(["#{key} IN (?)", join_ids])
-          records = reflection.klass.where(where_sql)
 
-          # Preventing the reflection from being loaded on the
-          # last reflection in the chain, that way anything the user
-          # wants to apply to the reflection will still work.
-          foreign_key = next_reflection.join_keys.foreign_key
-          [next_reflection, records.pluck(foreign_key)]
+          # "WHERE key IN ()" is invalid SQL and will happen if join_ids is empty,
+          # so we gotta catch it here in ruby
+          record_ids = if join_ids.present?
+            where_sql = ActiveRecord::Base.sanitize_sql(["#{key} IN (?)", join_ids])
+            records = reflection.klass.where(where_sql)
+            foreign_key = next_reflection.join_keys.foreign_key
+            records.pluck(foreign_key)
+          else
+            []
+          end
+
+          [next_reflection, record_ids]
         end
 
         key = last_reflection.join_keys.key
-        last_reflection.klass.where(key => last_join_ids)
+        where_sql = ActiveRecord::Base.sanitize_sql(["#{key} IN (?)", last_join_ids])
+        last_reflection.klass.where(where_sql)
       end
     end
 

--- a/lib/active_record/associations/has_many_split_through_association.rb
+++ b/lib/active_record/associations/has_many_split_through_association.rb
@@ -5,11 +5,11 @@ module ActiveRecord
     class SplitAssociationScope < AssociationScope
       def scope(association)
         # source of the through reflection
-        reflection = association.reflection
+        source_reflection = association.reflection
         #remove all previously set scope of passed in association
         scope = association.klass.unscoped
 
-        chain = get_chain(reflection, association, scope.alias_tracker)
+        chain = get_chain(source_reflection, association, scope.alias_tracker)
 
         reverse_chain = chain.reverse
         first_reflection = reverse_chain.shift

--- a/lib/active_record/associations/has_many_split_through_association.rb
+++ b/lib/active_record/associations/has_many_split_through_association.rb
@@ -10,20 +10,14 @@ module ActiveRecord
         chain = get_chain(reflection, association, scope.alias_tracker)
 
         join_ids = [association.owner.id]
-        records = nil
 
-        reverse_chain = chain.reverse
-        last_reflection = reverse_chain.last
-
-        m = reverse_chain.inject do |acc, refl|
+        m = chain.reverse.inject do |acc, refl|
           records = acc.klass.unscoped.where(acc.join_keys.key => join_ids)
           # Preventing the reflection from being loaded on the
           # last reflection in the chain, that way anything the user
           # wants to apply to the reflection will still work.
-          records = records.select(refl.join_keys.foreign_key)
-          join_ids = records.map { |x|
-            x[refl.join_keys.foreign_key]
-          }
+          join_ids = records.pluck(refl.join_keys.foreign_key)
+
           refl
         end
 

--- a/lib/active_record/associations/has_many_split_through_association.rb
+++ b/lib/active_record/associations/has_many_split_through_association.rb
@@ -34,9 +34,13 @@ module ActiveRecord
           [next_reflection, record_ids]
         end
 
-        key = last_reflection.join_keys.key
-        where_sql = ActiveRecord::Base.sanitize_sql(["#{key} IN (?)", last_join_ids])
-        last_reflection.klass.where(where_sql)
+        if last_join_ids.present?
+          key = last_reflection.join_keys.key
+          where_sql = ActiveRecord::Base.sanitize_sql(["#{key} IN (?)", last_join_ids])
+          last_reflection.klass.where(where_sql)
+        else
+          last_reflection.klass.none
+        end
       end
     end
 

--- a/test/active_record_has_many_split_through_test.rb
+++ b/test/active_record_has_many_split_through_test.rb
@@ -21,12 +21,20 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
     assert_equal 1, @company.ships.count
   end
 
+  def test_coutning_through_other_database_using_custom_foreign_key
+    assert_equal 3, @ship.containers.count
+  end
+
   def test_fetching_through_same_database
     assert_equal @employee.id, @company.employees.first.id
   end
 
   def test_fetching_through_other_database
     assert_equal @ship.id, @company.ships.first.id
+  end
+
+  def test_fetching_through_other_database_using_custom_foreign_key
+    assert_equal @container1.id, @dock.ships.first.id
   end
 
   def test_appending_through_same_database
@@ -41,6 +49,12 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
     end
   end
 
+  def test_appending_through_other_database_using_custom_foreign_key
+    assert_difference(->() { @ship.containers.reload.size }) do
+      @dock.containers.create()
+    end
+  end
+
   def test_to_a_through_same_database
     assert_equal [@employee, @employee2], @company.employees.sort.to_a
   end
@@ -49,8 +63,16 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
     assert_equal [@ship], @company.ships.to_a
   end
 
+  def test_to_a_through_other_database_using_custom_foreign_key
+    assert_equal [@container1, @container2, @container3], @dock.containers.to_a
+  end
+
   def test_empty_through_other_database
     assert_equal [], @company3.whistles
+  end
+
+  def test_empty_through_other_database_using_custom_foreign_key
+    assert_equal [], @dock2.containers
   end
 
   def test_pluck_through_same_database
@@ -59,6 +81,11 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
 
   def test_pluck_through_other_database
     assert_equal Ship.where(dock: @dock).pluck(:id), @company.ships.pluck(:id)
+  end
+
+  def test_pluck_through_other_database_using_custom_foreign_key
+    assert_equal Container.where(dock: @dock).pluck(:registration_number),
+      @ship.containers.pluck(:registration_number)
   end
 
   # through a through
@@ -88,6 +115,10 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
     @dock = @company.docks.create!(name: "Primary")
     @dock2 = @company2.docks.create!(name: "Primary")
 
+    @container1 = @dock.containers.create!()
+    @container2 = @dock.containers.create!()
+    @container3 = @dock.containers.create!()
+
     @ship = @dock.ships.create!(name: "Alton")
     @ship2 = @dock2.ships.create!(name: "Not Alton")
 
@@ -106,6 +137,7 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
     Dock.connection.execute("delete from docks;")
     Ship.connection.execute("delete from ships;")
     Whistle.connection.execute("delete from whistles;")
+    Container.connection.execute("delete from containers;")
   end
 
   def assert_difference(record_count)

--- a/test/active_record_has_many_split_through_test.rb
+++ b/test/active_record_has_many_split_through_test.rb
@@ -49,6 +49,10 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
     assert_equal [@ship], @company.ships.to_a
   end
 
+  def test_empty_through_other_database
+    assert_equal [], @company3.whistles
+  end
+
   def test_pluck_through_same_database
     assert_equal Employee.all.pluck(:id), @company.employees.pluck(:id)
   end
@@ -72,6 +76,7 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
   def create_fixtures
     @company = ShippingCompany.create!(name: "GitHub")
     @company2 = ShippingCompany.create!(name: "Microsoft")
+    @company3 = ShippingCompany.create!(name: "Wunderlist")
 
     @office = @company.offices.create!(name: "Back Office")
     @office2 = @company.offices.create!(name: "Front Office")

--- a/test/active_record_has_many_split_through_test.rb
+++ b/test/active_record_has_many_split_through_test.rb
@@ -21,8 +21,8 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
     assert_equal 1, @company.ships.count
   end
 
-  def test_coutning_through_other_database_using_custom_foreign_key
-    assert_equal 3, @ship.containers.count
+  def test_counting_through_other_database_using_custom_foreign_key
+    assert_equal 3, @company.containers.count
   end
 
   def test_fetching_through_same_database
@@ -34,7 +34,7 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
   end
 
   def test_fetching_through_other_database_using_custom_foreign_key
-    assert_equal @container1.id, @dock.ships.first.id
+    assert_equal @container1.id, @company.containers.first.id
   end
 
   def test_appending_through_same_database
@@ -50,7 +50,7 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
   end
 
   def test_appending_through_other_database_using_custom_foreign_key
-    assert_difference(->() { @ship.containers.reload.size }) do
+    assert_difference(->() { @company.containers.reload.size }) do
       @dock.containers.create()
     end
   end
@@ -64,7 +64,7 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
   end
 
   def test_to_a_through_other_database_using_custom_foreign_key
-    assert_equal [@container1, @container2, @container3], @dock.containers.to_a
+    assert_equal [@container1, @container2, @container3], @company.containers.to_a
   end
 
   def test_empty_through_other_database
@@ -72,7 +72,7 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
   end
 
   def test_empty_through_other_database_using_custom_foreign_key
-    assert_equal [], @dock2.containers
+    assert_equal [], @company2.containers
   end
 
   def test_pluck_through_same_database
@@ -85,7 +85,7 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
 
   def test_pluck_through_other_database_using_custom_foreign_key
     assert_equal Container.where(dock: @dock).pluck(:registration_number),
-      @ship.containers.pluck(:registration_number)
+      @company.containers.pluck(:registration_number)
   end
 
   # through a through

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -27,3 +27,8 @@ C.connection.create_table :ships, force: true do |t|
   t.string :name
   t.references :dock
 end
+
+D.connection.create_table :containers, id: false, force: true do |t|
+  t.primary_key :registration_number
+  t.references :dock
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,13 +51,21 @@ end
 class Dock < B
   belongs_to :shipping_company # A
   has_many :ships # C
+  has_many :containers # D
 end
 
 class Ship < C
   belongs_to :dock # B
   has_many :whistles # A
-  has_many :chairs # C
-  has_many :chair_legs, through: :chairs
+  has_many :containers,
+    foreign_key: "container_registration_number_id",
+    through: :dock,
+    split: true # C → D
+end
+
+class Container < D
+  self.primary_key = "registration_number"
+  belongs_to :dock # C
 end
 
 require_relative "schema"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,6 +33,7 @@ class ShippingCompany < A
   has_many :docks # B
   has_many :ships, through: :docks, split: true # B → C
   has_many :whistles, through: :ships, split: true # C → A
+  has_many :containers, through: :docks, split: true # B → D
 end
 
 class Office < A
@@ -60,12 +61,12 @@ class Ship < C
   has_many :containers,
     foreign_key: "container_registration_number_id",
     through: :dock,
-    split: true # C → D
+    split: true # B → D
 end
 
 class Container < D
   self.primary_key = "registration_number"
-  belongs_to :dock # C
+  belongs_to :dock # B
 end
 
 require_relative "schema"


### PR DESCRIPTION
When we join tables we need to select the correct foreign key, which
isn't always `id`.

- [x] Prototype implementation 
- [ ] Tests