### PR TITLE
small refactor to clarify names used

### DIFF
--- a/lib/active_record/associations/has_many_split_through_association.rb
+++ b/lib/active_record/associations/has_many_split_through_association.rb
@@ -4,24 +4,31 @@ module ActiveRecord
   module Associations
     class SplitAssociationScope < AssociationScope
       def scope(association)
+        # source of the through reflection
         reflection = association.reflection
+        #remove all previously set scope of passed in association
         scope = association.klass.unscoped
 
         chain = get_chain(reflection, association, scope.alias_tracker)
 
         reverse_chain = chain.reverse
-        first_refl = reverse_chain.shift
+        first_reflection = reverse_chain.shift
         first_join_ids = [association.owner.id]
+        initial_values = [first_reflection, first_join_ids]
 
-        last_refl, last_join_ids = reverse_chain.inject([first_refl, first_join_ids]) do |(prev_refl, prev_join_ids), next_refl|
-          records = prev_refl.klass.unscoped.where(prev_refl.join_keys.key => prev_join_ids)
+        last_reflection, join_ids = reverse_chain.inject(initial_values) do |(reflection, join_ids), next_reflection|
+          key = reflection.join_keys.key
+          records = reflection.klass.where(key => join_ids)
+
           # Preventing the reflection from being loaded on the
           # last reflection in the chain, that way anything the user
           # wants to apply to the reflection will still work.
-          [next_refl, records.pluck(next_refl.join_keys.foreign_key)]
+          foreign_key = next_reflection.join_keys.foreign_key
+          [next_reflection, records.pluck(foreign_key)]
         end
 
-        last_refl.klass.unscoped.where(last_refl.join_keys.key => last_join_ids)
+        key = last_reflection.join_keys.key
+        last_reflection.klass.where(key => join_ids)
       end
     end
 

--- a/lib/active_record/associations/has_many_split_through_association.rb
+++ b/lib/active_record/associations/has_many_split_through_association.rb
@@ -10,20 +10,14 @@ module ActiveRecord
         chain = get_chain(reflection, association, scope.alias_tracker)
 
         join_ids = [association.owner.id]
-        records = nil
 
-        reverse_chain = chain.reverse
-        last_reflection = reverse_chain.last
-
-        m = reverse_chain.inject do |acc, refl|
+        m = chain.reverse.inject do |acc, refl|
           records = acc.klass.unscoped.where(acc.join_keys.key => join_ids)
           # Preventing the reflection from being loaded on the
           # last reflection in the chain, that way anything the user
           # wants to apply to the reflection will still work.
-          records = records.select(refl.join_keys.foreign_key)
-          join_ids = records.map { |x|
-            x[refl.join_keys.foreign_key]
-          }
+          join_ids = records.pluck(refl.join_keys.foreign_key)
+
           refl
         end
 


### PR DESCRIPTION
I also removed the use of `unscoped` after seeing that tests still pass. It could also be that we are missing tests that should dictate that reflections should be unscoped.