### PR TITLE
Support `source_type` as an option

### DIFF
--- a/lib/active_record/associations/has_many_split_through_association.rb
+++ b/lib/active_record/associations/has_many_split_through_association.rb
@@ -54,14 +54,6 @@ module ActiveRecord
           last_reflection.klass.none
         end
       end
-
-      def apply_scope(scope, table, key, value)
-        if scope.table == table
-          scope.where!(key => value)
-        else
-          scope.where!(table.name => { key => value })
-        end
-      end
     end
 
     # = Active Record Has Many Through Association

--- a/lib/active_record/associations/has_many_split_through_association.rb
+++ b/lib/active_record/associations/has_many_split_through_association.rb
@@ -6,6 +6,8 @@ module ActiveRecord
       def scope(association)
         # source of the through reflection
         source_reflection = association.reflection
+        options = source_reflection.options
+
         # remove all previously set scopes of passed in association
         scope = association.klass.unscoped
 
@@ -23,8 +25,18 @@ module ActiveRecord
           # "WHERE key IN ()" is invalid SQL and will happen if join_ids is empty,
           # so we gotta catch it here in ruby
           record_ids = if join_ids.present?
+
             where_sql = ActiveRecord::Base.sanitize_sql(["#{key} IN (?)", join_ids])
             records = reflection.klass.where(where_sql)
+
+            if options[:source_type]
+              table = reflection.aliased_table
+              type = "#{options[:source]}_type"
+              polymorphic_type = transform_value(options[:source_type])
+
+              records = apply_scope(records, table, type, polymorphic_type)
+            end
+
             foreign_key = next_reflection.join_keys.foreign_key
             records.pluck(foreign_key)
           else
@@ -40,6 +52,14 @@ module ActiveRecord
           last_reflection.klass.where(where_sql)
         else
           last_reflection.klass.none
+        end
+      end
+
+      def apply_scope(scope, table, key, value)
+        if scope.table == table
+          scope.where!(key => value)
+        else
+          scope.where!(table.name => { key => value })
         end
       end
     end

--- a/test/active_record_has_many_split_through_test.rb
+++ b/test/active_record_has_many_split_through_test.rb
@@ -12,9 +12,11 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::ActiveRecordHasManySplitThrough::VERSION
   end
-  
+
   def test_employee_has_one_favorite_ship
     assert_equal 1, @employee.favorite_ships.count
+    assert_includes @employee.favorite_ships, @ship2
+    refute_includes @employee.favorite_ships, @dock
   end
 
   def test_counting_through_same_database
@@ -132,7 +134,7 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
 
     @ship2.whistles.create!()
     @ship2.whistles.create!()
-    
+
     @favorite_ship = Favorite.create!(employee: @employee, favoritable: @ship2)
     @favorite_dock = Favorite.create!(employee: @employee, favoritable: @dock)
     @decoy_ship = Ship.where(id: @favorite_dock.id).first_or_create
@@ -146,6 +148,7 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
     Ship.connection.execute("delete from ships;")
     Whistle.connection.execute("delete from whistles;")
     Container.connection.execute("delete from containers;")
+    Favorite.connection.execute("delete from favorites;")
   end
 
   def assert_difference(record_count)

--- a/test/active_record_has_many_split_through_test.rb
+++ b/test/active_record_has_many_split_through_test.rb
@@ -12,6 +12,10 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::ActiveRecordHasManySplitThrough::VERSION
   end
+  
+  def test_employee_has_one_favorite_ship
+    assert_equal 1, @employee.favorite_ships.count
+  end
 
   def test_counting_through_same_database
     assert_equal 2, @company.employees.count
@@ -128,6 +132,10 @@ class ActiveRecordHasManySplitThroughTest < Minitest::Test
 
     @ship2.whistles.create!()
     @ship2.whistles.create!()
+    
+    @favorite_ship = Favorite.create!(employee: @employee, favoritable: @ship2)
+    @favorite_dock = Favorite.create!(employee: @employee, favoritable: @dock)
+    @decoy_ship = Ship.where(id: @favorite_dock.id).first_or_create
   end
 
   def remove_everything

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -14,6 +14,7 @@ A.connection.create_table :employees, force: true do |t|
   t.references :office
 end
 
+
 A.connection.create_table :whistles, force: true do |t|
   t.references :ship
 end
@@ -21,6 +22,13 @@ end
 B.connection.create_table :docks, force: true do |t|
   t.string :name
   t.references :shipping_company
+end
+
+
+B.connection.create_table :favorites, force: true do |t|
+  t.integer :favoritable_id
+  t.integer :employee_id
+  t.string  :favoritable_type
 end
 
 C.connection.create_table :ships, force: true do |t|

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -14,7 +14,6 @@ A.connection.create_table :employees, force: true do |t|
   t.references :office
 end
 
-
 A.connection.create_table :whistles, force: true do |t|
   t.references :ship
 end
@@ -23,7 +22,6 @@ B.connection.create_table :docks, force: true do |t|
   t.string :name
   t.references :shipping_company
 end
-
 
 B.connection.create_table :favorites, force: true do |t|
   t.integer :favoritable_id

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,7 +44,7 @@ end
 class Employee < A
   belongs_to :office # A
   has_many :favorites
-  
+
   has_many :favorite_ships,
     through: :favorites,
     source: :favoritable,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,6 +43,13 @@ end
 
 class Employee < A
   belongs_to :office # A
+  has_many :favorites
+  
+  has_many :favorite_ships,
+    through: :favorites,
+    source: :favoritable,
+    source_type: "Ship",
+    split: true
 end
 
 class Whistle < A
@@ -53,11 +60,18 @@ class Dock < B
   belongs_to :shipping_company # A
   has_many :ships # C
   has_many :containers # D
+  has_many :favorites, as: :favoritable #B
+end
+
+class Favorite < B
+  belongs_to :employee
+  belongs_to :favoritable, polymorphic: true
 end
 
 class Ship < C
   belongs_to :dock # B
   has_many :whistles # A
+  has_many :favorites, as: :favoritable #B
   has_many :containers,
     foreign_key: "container_registration_number_id",
     through: :dock,


### PR DESCRIPTION
If you have a HMT association where the association is polymorphic and you're using `source_type`, the split association will not include the extra conditional constraining the source type. 

The final scope returned is for the correct table, but because that first query was missing the extra constraint it might contain IDs that aren't correct:

```
(byebug) @employee.favorite_ships
D, [2019-09-11T17:37:17.697920 #44274] DEBUG -- :    (0.1ms)  SELECT "favorites"."favoritable_id" FROM "favorites" WHERE (employee_id IN (15)) <-- this should also include AND favoritable_type = "Ship"
D, [2019-09-11T17:37:17.698328 #44274] DEBUG -- :   Ship Load (0.1ms)  SELECT  "ships".* FROM "ships" WHERE (id IN (17,15)) LIMIT ?  [["LIMIT", 11]]
```